### PR TITLE
Bump build timeout to 9 hours when using RunsOn runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,6 +236,7 @@ jobs:
               f.write(f"matrix={json.dumps(matrix)}\\n")
 
   build:
+    timeout-minutes: ${{ inputs.build_type == 'default' && 360 || 540 }}
     name: build-${{ matrix.arch }}
     runs-on: ${{ matrix.runner }}
     needs: [validate-manifest, setup-matrix]


### PR DESCRIPTION
Required for org.chromium.Chromium ARM build as that has an additional Clang build step that ends up taking an hour or so.