### PR TITLE
Add link to enqueued comment

### DIFF
--- a/app/routes/webhooks.py
+++ b/app/routes/webhooks.py
@@ -269,7 +269,7 @@ async def create_pipeline(event: WebhookEvent) -> uuid.UUID | None:
             await create_pr_comment(
                 git_repo=git_repo,
                 pr_number=pr_number,
-                comment="🚧 Test build enqueued.",
+                comment="🚧 Test build [enqueued](https://github.com/flathub-infra/vorarbeiter/actions/workflows/build.yml).",
             )
         except ValueError:
             logger.error(


### PR DESCRIPTION
This adds a direct link to the queue to the comment, so users can see how many Flatpaks are before their app.