### PR TITLE
tests: Add missing get_build_info mock

### DIFF
--- a/tests/test_check_jobs_endpoint.py
+++ b/tests/test_check_jobs_endpoint.py
@@ -156,6 +156,10 @@ async def test_check_jobs_endpoint_all_failed(client, db_session_maker, auth_hea
         mock_fm_instance = AsyncMock()
         mock_fm_class.return_value = mock_fm_instance
 
+        mock_fm_instance.get_build_info = AsyncMock(
+            return_value={"build": {"commit_job_id": 12345}}
+        )
+
         mock_fm_instance.get_job = AsyncMock(return_value={"status": 3})
 
         response = client.post(


### PR DESCRIPTION
Fixes the warning

```
tests/test_check_jobs_endpoint.py::test_check_jobs_endpoint_all_failed
  /home/bbhtt/Git/github/flathub-vorarbeiter/app/services/job_monitor.py:28: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    if await self._fetch_missing_job_ids(pipeline):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```