### PR TITLE
Add emergency flag to disable test-build triggers and notify PRs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
     sentry_dsn: str | None = None
     ff_reprocheck_issues: bool = False
     ff_admin_ping_comment: bool = False
+    ff_disable_test_builds: bool = False
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/app/routes/webhooks.py
+++ b/app/routes/webhooks.py
@@ -856,6 +856,19 @@ async def create_pipeline(event: WebhookEvent) -> uuid.UUID | None:
             if not pr_url or issue_number is None:
                 return None
 
+            if settings.ff_disable_test_builds:
+                await create_pr_comment(
+                    git_repo=repo,
+                    pr_number=issue_number,
+                    comment="Test builds are currently disabled. Please refer to https://status.flathub.org for updates. You can retry this build when the incident is over.",
+                )
+                logger.info(
+                    "Test build trigger ignored because test builds are disabled",
+                    repo=repo,
+                    pr_number=issue_number,
+                )
+                return None
+
             pr_ref = f"refs/pull/{issue_number}/head"
 
             github_api_url = f"https://api.github.com/repos/{repo}/pulls/{issue_number}"


### PR DESCRIPTION
### Motivation
- Provide an operational kill-switch to stop dispatching test builds triggered via PR comments during incidents.
- Ensure contributors receive a clear, consistent message pointing them to the status page and instructing when to retry.

### Description
- Added a new feature flag `ff_disable_test_builds` to `Settings` in `app/config.py` to control disabling test-build triggers.
- Updated the `create_pipeline` flow in `app/routes/webhooks.py` to short-circuit handling of `"bot, build"` PR comments when the flag is enabled, posting the exact message via `create_pr_comment` and skipping pipeline creation. 
- Added tests in `tests/test_webhooks.py` exercising both the disabled path (comment posted and pipeline skipped) and the enabled path (pipeline proceeds normally). 
- Modified files: `app/config.py`, `app/routes/webhooks.py`, and `tests/test_webhooks.py`.

### Testing
- Running `pytest -q tests/test_webhooks.py -k "bot_build_disabled or bot_build_enabled or create_pipeline_comment"` initially failed in the base environment due to a missing `fastapi` dependency. 
- Re-running under the project runner with `uv run pytest -q tests/test_webhooks.py -k "bot_build_disabled or bot_build_enabled or create_pipeline_comment"` succeeded with `3 passed, 70 deselected`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999e182004c8321afc61876e19b5b47)